### PR TITLE
Integrate with our org's OpenAM IDP

### DIFF
--- a/example/idtoken/app.go
+++ b/example/idtoken/app.go
@@ -37,7 +37,7 @@ func main() {
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  "http://127.0.0.1:5556/auth/google/callback",
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, "profile"},
 	}
 
 	state := "foobar" // Don't do this in production.

--- a/example/nonce/app.go
+++ b/example/nonce/app.go
@@ -41,7 +41,7 @@ func main() {
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  "http://127.0.0.1:5556/auth/google/callback",
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, "profile"},
 	}
 
 	state := "foobar" // Don't do this in production.

--- a/example/userinfo/app.go
+++ b/example/userinfo/app.go
@@ -32,7 +32,7 @@ func main() {
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  "http://127.0.0.1:5556/auth/google/callback",
-		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+		Scopes:       []string{oidc.ScopeOpenID, "profile"},
 	}
 
 	state := "foobar" // Don't do this in production.

--- a/jose/claims.go
+++ b/jose/claims.go
@@ -27,6 +27,20 @@ func (c Claims) StringClaim(name string) (string, bool, error) {
 	return v, true, nil
 }
 
+func (c Claims) StringFromArrayClaim(name string) (string, bool, error) {
+	cl, ok := c[name]
+	if !ok {
+		return "", false, nil
+	}
+
+	v, ok := cl.([]interface{})
+	if !ok {
+		return "", false, fmt.Errorf("unable to parse claim as string: %v", name)
+	}
+
+	return v[0].(string), true, nil
+}
+
 func (c Claims) StringsClaim(name string) ([]string, bool, error) {
 	cl, ok := c[name]
 	if !ok {

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -255,7 +255,8 @@ func (c *Client) UserCredsToken(username, password string) (result TokenResponse
 // If 'grantType' == GrantTypeRefreshToken, then 'value' should be the refresh token.
 func (c *Client) RequestToken(grantType, value string) (result TokenResponse, err error) {
 	v := c.commonURLValues()
-
+	v.Del("scope")
+	v.Del("client_id")
 	v.Set("grant_type", grantType)
 	switch grantType {
 	case GrantTypeAuthCode:

--- a/oidc/client.go
+++ b/oidc/client.go
@@ -23,7 +23,7 @@ const (
 )
 
 var (
-	DefaultScope = []string{"openid", "email", "profile"}
+	DefaultScope = []string{"openid", "profile"}
 
 	supportedAuthMethods = map[string]struct{}{
 		oauth2.AuthMethodClientSecretBasic: struct{}{},

--- a/oidc/client_test.go
+++ b/oidc/client_test.go
@@ -36,7 +36,7 @@ func TestNewClientScopeDefault(t *testing.T) {
 		},
 		{
 			// Custom scope equal to default
-			c: ClientConfig{RedirectURL: "http://example.com/redirect", Scope: []string{"openid", "email", "profile"}},
+			c: ClientConfig{RedirectURL: "http://example.com/redirect", Scope: []string{"openid", "profile"}},
 			e: DefaultScope,
 		},
 		{


### PR DESCRIPTION
This change addresses the issue of OpenAM's RP auth flow not allowing
multiple auth methods for the agent in one request and that the scope
field should not be in the access token call after the authorize step.
It also addresses that we don't have email in our scope and that the
audience is returned as an array.